### PR TITLE
fix(deps): override defu to patch prototype pollution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1966,7 +1966,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.3.0.tgz",
       "integrity": "sha512-O8jXi0Wv/dFc7BkJkFC0SlW8dT0OjOWvBHakVaOAKVlAKNuQBXfZzLe48bIYAvMhPe0lFppyWoN/SyuIfVBvkg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@module-federation/inject-external-runtime-core-plugin": {
@@ -2039,7 +2038,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.3.0.tgz",
       "integrity": "sha512-9vv0Ah8Tg3E5mBlj29n1boN0bPKbqhw7QBWZCDm2Mou0uXb8x/ycgFR1EPq937LCScBUl0LiFp53KSjeyT75aQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/error-codes": "2.3.0",
@@ -2051,7 +2049,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.3.0.tgz",
       "integrity": "sha512-OvBNIAGM7Xj0dUOBG5jx7zuZaRLDHb5Wcb7pstwqJo5WYqj7gzA9X+QmI+jsQ9jY74Nlfx9vrvW6LlHukIRH/A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/error-codes": "2.3.0",
@@ -2073,7 +2070,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.3.0.tgz",
       "integrity": "sha512-xj90q4eILkFA1J30wVQYEIWAEh39tfLbCIw1dz3QXUL2TtD/h19H1rZlRkrtAyUxV6xKjp17EMkyGSHzstf1OA==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "node-fetch": "^3.3.2"
@@ -6171,9 +6167,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
+      "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "*.{js,jsx,ts,tsx}": "oxlint --fix",
     "*.{js,jsx,ts,tsx,css,md,json}": "oxfmt"
   },
+  "overrides": {
+    "defu": ">=6.1.5"
+  },
   "devDependencies": {
     "@module-federation/enhanced": "^2.3.0",
     "@swc/core": "^1.15.0",


### PR DESCRIPTION
## Summary
- Adds npm override for defu >= 6.1.5 to resolve Dependabot alert:
  - HIGH: Prototype pollution via __proto__ key in defaults argument

## Test plan
- [x] npm install succeeds
- [x] defu resolves to >= 6.1.5 (6.1.6)
- [x] Build passes (all 5 packages)