### PR TITLE
chore: resolve Dependabot security alerts (lodash, axios)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1915,25 +1915,6 @@
         }
       }
     },
-    "node_modules/@module-federation/dts-plugin/node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@module-federation/dts-plugin/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@module-federation/enhanced": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.3.1.tgz",
@@ -2107,9 +2088,9 @@
       }
     },
     "node_modules/@module-federation/vite": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@module-federation/vite/-/vite-1.14.1.tgz",
-      "integrity": "sha512-FmnskszFQpWWJAXMi/YZY5mnBqLHIjpGw87W+Ooa601rcmzM5h/Jf8FdOj73ElBTA3FuLw/if0kL/JzOsS/H7Q==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@module-federation/vite/-/vite-1.14.2.tgz",
+      "integrity": "sha512-SkmwmHzjP73oSpSUIhn/CuSC7wgF5jJEuA66WGVqkkglWPGlx1Zpc9B8Ec/xSgYsA/cR1OHOwC1YaU6UTytpkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5608,6 +5589,18 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-dead-code-elimination": {
@@ -9355,6 +9348,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "*.{js,jsx,ts,tsx,css,md,json}": "oxfmt"
   },
   "overrides": {
-    "defu": ">=6.1.5"
+    "defu": ">=6.1.5",
+    "axios": ">=1.15.0"
   },
   "devDependencies": {
     "@module-federation/enhanced": "^2.3.1",


### PR DESCRIPTION
## Summary
- **lodash**: high/critical advisories (`_.template` code injection, `_.unset`/`_.omit` prototype pollution) resolved via lockfile update
- **axios**: added npm override pinning `axios >=1.15.0` to patch SSRF (NO_PROXY bypass) and cloud-metadata exfiltration advisories reaching us through `@module-federation/dts-plugin`

Supersedes #15, which was based on the pre-turborepo layout and is no longer applicable.

## Test plan
- [x] \`npm audit\` reports 0 vulnerabilities
- [ ] CI green
- [ ] \`npm run build\` — note: \`portal-shell-ssr\` build is broken on main independently (missing \`react-router\` dep), unrelated to this change